### PR TITLE
fix-phpdoc-method-structure

### DIFF
--- a/src/Denormalizer/Denormalizer.php
+++ b/src/Denormalizer/Denormalizer.php
@@ -147,6 +147,7 @@ final class Denormalizer implements DenormalizerInterface
      * @param DenormalizerContextInterface         $context
      * @param DenormalizationFieldMappingInterface $denormalizationFieldMapping
      * @param string                               $path
+     * @param string                               $name
      * @param array                                $data
      * @param object                               $object
      */

--- a/src/Denormalizer/DenormalizerContextBuilderInterface.php
+++ b/src/Denormalizer/DenormalizerContextBuilderInterface.php
@@ -7,7 +7,7 @@ namespace Chubbyphp\Deserialization\Denormalizer;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
- * @method setAttributes(array $attributes): self
+ * @method DenormalizerContextBuilderInterface setAttributes(array $attributes)
  */
 interface DenormalizerContextBuilderInterface
 {

--- a/src/Denormalizer/DenormalizerContextInterface.php
+++ b/src/Denormalizer/DenormalizerContextInterface.php
@@ -7,9 +7,9 @@ namespace Chubbyphp\Deserialization\Denormalizer;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
- * @method getAttributes(): array
- * @method getAttribute(string $name, $default = null)
- * @method withAttribute(string $name, $value): self
+ * @method array                        getAttributes()
+ * @method mixed                        getAttribute(string $name, $default = null)
+ * @method DenormalizerContextInterface withAttribute(string $name, $value)
  */
 interface DenormalizerContextInterface
 {

--- a/src/Mapping/DenormalizationFieldMappingBuilder.php
+++ b/src/Mapping/DenormalizationFieldMappingBuilder.php
@@ -50,9 +50,9 @@ final class DenormalizationFieldMappingBuilder implements DenormalizationFieldMa
     }
 
     /**
-     * @param string $name
-     * @param bool   $emptyToNull
-     * @param FieldDenormalizerInterface|null
+     * @param string                          $name
+     * @param bool                            $emptyToNull
+     * @param FieldDenormalizerInterface|null $fieldDenormalizer
      *
      * @return DenormalizationFieldMappingBuilderInterface
      */

--- a/src/Mapping/DenormalizationFieldMappingBuilderInterface.php
+++ b/src/Mapping/DenormalizationFieldMappingBuilderInterface.php
@@ -8,7 +8,7 @@ use Chubbyphp\Deserialization\Denormalizer\FieldDenormalizerInterface;
 use Chubbyphp\Deserialization\Policy\PolicyInterface;
 
 /**
- * @method setPolicy(PolicyInterface $policy): self
+ * @method DenormalizationFieldMappingBuilderInterface setPolicy(PolicyInterface $policy)
  */
 interface DenormalizationFieldMappingBuilderInterface
 {
@@ -20,10 +20,10 @@ interface DenormalizationFieldMappingBuilderInterface
     public static function create(string $name): self;
 
     /**
-     * @param string                        $name
-     * @param FieldNormalizerInterface|null $fieldNormalizer
+     * @param string                          $name
+     * @param FieldDenormalizerInterface|null $fieldNormalizer
      *
-     * @return NormalizationFieldMappingBuilderInterface
+     * @return DenormalizationFieldMappingBuilderInterface
      */
     //public static function create(string $name, FieldNormalizerInterface $fieldNormalizer = null): self;
 

--- a/src/Mapping/DenormalizationFieldMappingInterface.php
+++ b/src/Mapping/DenormalizationFieldMappingInterface.php
@@ -8,7 +8,7 @@ use Chubbyphp\Deserialization\Denormalizer\FieldDenormalizerInterface;
 use Chubbyphp\Deserialization\Policy\PolicyInterface;
 
 /**
- * @method getPolicy(): PolicyInterface
+ * @method PolicyInterface getPolicy()
  */
 interface DenormalizationFieldMappingInterface
 {


### PR DESCRIPTION
Changelog:
- the PHPDoc ```@method``` structure has the return type before the method name - therefor this is now adjusted here
- fix some PHPDoc issues