### PR TITLE
Handle array key numeric string cast to integer 

### DIFF
--- a/src/Denormalizer/Denormalizer.php
+++ b/src/Denormalizer/Denormalizer.php
@@ -158,7 +158,7 @@ final class Denormalizer implements DenormalizerInterface
     }
 
     /**
-     * @param array<int, string> $names
+     * @param array<int, string|int> $names
      */
     private function handleNotAllowedAdditionalFields(string $path, array $names): void
     {
@@ -218,7 +218,7 @@ final class Denormalizer implements DenormalizerInterface
     }
 
     /**
-     * @param array<int, string> $names
+     * @param array<int, string|int> $names
      *
      * @return array<int, string>
      */
@@ -226,7 +226,7 @@ final class Denormalizer implements DenormalizerInterface
     {
         $subPaths = [];
         foreach ($names as $name) {
-            $subPaths[] = $this->getSubPathByName($path, $name);
+            $subPaths[] = $this->getSubPathByName($path, (string) $name);
         }
 
         return $subPaths;

--- a/tests/Integration/DeserializerTest.php
+++ b/tests/Integration/DeserializerTest.php
@@ -436,6 +436,34 @@ final class DeserializerTest extends TestCase
         );
     }
 
+    public function testDenormalizeWithKeyCastToIntegerAdditionalFieldsExpectsException(): void
+    {
+        $this->expectException(DeserializerRuntimeException::class);
+        $this->expectExceptionMessage('There are additional field(s) at paths: "1"');
+
+        $childModelMapping = new ManyModelMapping();
+
+        $deserializer = new Deserializer(
+            new Decoder([new JsonTypeDecoder()]),
+            new Denormalizer(
+                new DenormalizerObjectMappingRegistry([
+                    new BaseManyModelMapping($childModelMapping, ['many-model']),
+                    $childModelMapping,
+                    new ModelMapping(),
+                ])
+            )
+        );
+
+        $data = json_encode(['name' => 'Name', '1' => 'value']);
+
+        $deserializer->deserialize(
+            Model::class,
+            $data,
+            'application/json',
+            DenormalizerContextBuilder::create()->setAllowedAdditionalFields([])->getContext()
+        );
+    }
+
     public function testDenormalizeWithAllowedAdditionalFields(): void
     {
         $childModelMapping = new ManyModelMapping();

--- a/tests/Unit/Denormalizer/DenormalizerTest.php
+++ b/tests/Unit/Denormalizer/DenormalizerTest.php
@@ -449,7 +449,7 @@ final class DenormalizerTest extends TestCase
         $denormalizer->denormalize(\stdClass::class, ['additionalData' => 'additionalData'], $context);
     }
 
-    public function testDenormalizeWithKeyCastToIntegerAdditionalData(): void
+    public function testDenormalizeWithKeyCastToIntegerAdditionalDataExpectsException(): void
     {
         $this->expectException(DeserializerRuntimeException::class);
         $this->expectExceptionMessage('There are additional field(s) at paths: "1"');


### PR DESCRIPTION
Handle array key numeric string cast to integer 

Native php functionality is to cast array numeric key string '8' to integer 8 `var_dump(['8' => 'value']);`
https://www.php.net/manual/en/language.types.array.php#example-64

Since `declare(strict_types=1);` is used in Denormalizer, TypeError will be thrown in above case. This PR intension is to prevent TypeError from being thrown when dealing with this specific case.

example json:
`
{
    "8": "value"
}
`

Proposed solution is to cast `$name` to string when call getSubPathByName method
`$this->getSubPathByName($path, (string) $name))`

I can give you more information on this. 
Sorry if PR description is not per standard.
