### PR TITLE
Return null in case when property is not initialized in property acce…

### DIFF
--- a/src/Accessor/PropertyAccessor.php
+++ b/src/Accessor/PropertyAccessor.php
@@ -41,6 +41,11 @@ final class PropertyAccessor implements AccessorInterface
             throw DeserializerLogicException::createMissingProperty($class, $this->property);
         }
 
+        $reflection = new \ReflectionProperty($class, $this->property);
+        if (!$reflection->isInitialized($object)) {
+            return null;
+        }
+
         $getter = \Closure::bind(
             fn ($property) => $this->{$property},
             $object,

--- a/tests/Unit/Accessor/PropertyAccessorTest.php
+++ b/tests/Unit/Accessor/PropertyAccessorTest.php
@@ -89,6 +89,22 @@ final class PropertyAccessorTest extends TestCase
         self::assertSame('Name', $accessor->getValue($object));
     }
 
+    public function testGetValueHandleUninitializedProperty(): void
+    {
+        $object = new class() {
+            private string $name;
+
+            public function getName(): string
+            {
+                return $this->name;
+            }
+        };
+
+        $accessor = new PropertyAccessor('name');
+
+        self::assertNull($accessor->getValue($object));
+    }
+
     public function testGetValueCanAccessPrivatePropertyThroughDoctrineProxyClass(): void
     {
         $object = new class() extends AbstractManyModel implements Proxy {


### PR DESCRIPTION
This PR is handling embedded properties that are not initialized before calling a getter in PropertyAccessor.php. 

This is needed in case when typed properties are used without default values and without doctrine, and as default values are not set, properties have "uninitialized" state. 

Because of that calling `getValue()` from EmbedManyFieldDenormalizer or EmbedOneFieldDenormalizer is throwing an error: `Fatal error: Uncaught Error: Typed property ... must not be accessed before initialization`, so this PR add a check if property is initialized and if it is, `$getter` is called, otherwise `null` is returned.